### PR TITLE
Compute terrain slope on the gpu

### DIFF
--- a/src/webgl/dem/decode_terrain_rgb.js
+++ b/src/webgl/dem/decode_terrain_rgb.js
@@ -1,0 +1,38 @@
+function getUniforms(opts = {}) {
+  const { imageTerrain, rScaler, bScaler, gScaler, offset } = opts;
+  if (!imageTerrain) {
+    return;
+  }
+
+  return {
+    bitmapTexture_terrain: imageTerrain,
+    rScaler,
+    bScaler,
+    gScaler,
+    offset,
+  };
+}
+
+const fs = `\
+uniform sampler2D bitmapTexture_terrain;
+uniform float rScaler;
+uniform float bScaler;
+uniform float gScaler;
+uniform float offset;
+
+float decode_slope(vec4 image, float rScaler, float bScaler, float gScaler, float offset) {
+  return (image.r * rScaler) + (image.g * gScaler) + (image.b * bScaler) + offset;
+}
+`;
+
+export default {
+  name: "decode-terrain-rgb",
+  fs,
+  getUniforms,
+  inject: {
+    "fs:DECKGL_CREATE_COLOR": `
+    vec4 image = texture2D(bitmapTexture_terrain, coord);
+    image.r = decode_slope(image, rScaler, bScaler, gScaler, offset);
+    `,
+  },
+};

--- a/src/webgl/dem/deriv.js
+++ b/src/webgl/dem/deriv.js
@@ -81,7 +81,7 @@ vec2 compute_deriv(sampler2D terrain) {
 `;
 
 export default {
-  name: "slope",
+  name: "terrain-deriv",
   fs,
   getUniforms,
   inject: {

--- a/src/webgl/dem/deriv.js
+++ b/src/webgl/dem/deriv.js
@@ -77,6 +77,7 @@ vec2 compute_deriv(sampler2D terrain) {
       (g + h + h + i) - (a + b + b + c)
   ) /  pow(2.0, (u_zoom - u_maxzoom) * exaggeration + 19.2562 - u_zoom);
   return deriv;
+}
 `;
 
 export default {

--- a/src/webgl/dem/slope.js
+++ b/src/webgl/dem/slope.js
@@ -1,0 +1,91 @@
+function getUniforms(opts = {}) {
+  const { imageColormap } = opts;
+
+  if (!imageColormap) {
+    return;
+  }
+
+  return {
+    bitmapTexture_colormap: imageColormap,
+  };
+}
+
+const fs = `\
+uniform sampler2D bitmapTexture_terrain;
+uniform float rScaler;
+uniform float bScaler;
+uniform float gScaler;
+uniform float offset;
+uniform vec2 imageDimensions;
+
+// Convert RGB-encoded elevation value to meters
+// Note: a _sampler_ must be provided, since you're fetching _neighboring_
+// texture values
+float getElevation(sampler2D texture, vec2 coord) {
+  vec4 data = texture2D(texture, coord);
+  return (data.r * rScaler) + (data.g * gScaler) + (data.b * bScaler) + offset;
+}
+
+
+// Modified from
+// https://github.com/mapbox/mapbox-gl-js/blob/master/src/shaders/hillshade_prepare.fragment.glsl
+vec2 compute_deriv(sampler2D terrain) {
+  vec2 epsilon = 1.0 / imageDimensions;
+
+  // queried pixels:
+  // +-----------+
+  // |   |   |   |
+  // | a | b | c |
+  // |   |   |   |
+  // +-----------+
+  // |   |   |   |
+  // | d | e | f |
+  // |   |   |   |
+  // +-----------+
+  // |   |   |   |
+  // | g | h | i |
+  // |   |   |   |
+  // +-----------+
+
+  float a = getElevation(terrain, v_pos + vec2(-epsilon.x, -epsilon.y));
+  float b = getElevation(terrain, v_pos + vec2(0, -epsilon.y));
+  float c = getElevation(terrain, v_pos + vec2(epsilon.x, -epsilon.y));
+  float d = getElevation(terrain, v_pos + vec2(-epsilon.x, 0));
+  // Never used
+  // float e = getElevation(terrain, v_pos);
+  float f = getElevation(terrain, v_pos + vec2(epsilon.x, 0));
+  float g = getElevation(terrain, v_pos + vec2(-epsilon.x, epsilon.y));
+  float h = getElevation(terrain, v_pos + vec2(0, epsilon.y));
+  float i = getElevation(terrain, v_pos + vec2(epsilon.x, epsilon.y));
+
+  // here we divide the x and y slopes by 8 * pixel size
+  // where pixel size (aka meters/pixel) is:
+  // circumference of the world / (pixels per tile * number of tiles)
+  // which is equivalent to: 8 * 40075016.6855785 / (512 * pow(2, u_zoom))
+  // which can be reduced to: pow(2, 19.25619978527 - u_zoom)
+  // we want to vertically exaggerate the hillshading though, because otherwise
+  // it is barely noticeable at low zooms. to do this, we multiply this by some
+  // scale factor pow(2, (u_zoom - u_maxzoom) * a) where a is an arbitrary value
+  // Here we use a=0.3 which works out to the expression below. see 
+  // nickidlugash's awesome breakdown for more info
+  // https://github.com/mapbox/mapbox-gl-js/pull/5286#discussion_r148419556
+  float exaggeration = u_zoom < 2.0 ? 0.4 : u_zoom < 4.5 ? 0.35 : 0.3;
+
+  // TODO: update to remove exaggeration
+  vec2 deriv = vec2(
+      (c + f + f + i) - (a + d + d + g),
+      (g + h + h + i) - (a + b + b + c)
+  ) /  pow(2.0, (u_zoom - u_maxzoom) * exaggeration + 19.2562 - u_zoom);
+  return deriv;
+`;
+
+export default {
+  name: "slope",
+  fs,
+  getUniforms,
+  inject: {
+    "fs:DECKGL_CREATE_COLOR": `
+    image = vec4(compute_deriv(bitmapTexture_terrain), 1.0, 1.0);
+    `,
+  },
+};

--- a/src/webgl/dem/slope.js
+++ b/src/webgl/dem/slope.js
@@ -1,0 +1,44 @@
+function getUniforms(opts = {}) {
+  const { latitude } = opts;
+
+  if (!latitude) {
+    return;
+  }
+
+  return {
+    latitude,
+  };
+}
+
+const fs = `\
+// todo make this a vec2, representing minLat, maxLat, and interpolate linearly
+// from pixel height?
+uniform float latitude;
+
+#define PI 3.1415926538
+
+float compute_mercator_scale_factor(float latitude) {
+  return 1.0 / cos(latitude * PI / 180.);
+}
+
+float compute_slope(vec2 deriv, float scaleFactor) {
+  // Divide by web mercator latitude scale factor.
+  // Computed as cos(latitude in radians)
+  float hypot = sqrt(pow(deriv.x, 2.0) + pow(deriv.y, 2.0));
+  float scaled = hypot / scaleFactor;
+  return degrees(atan(key / 8.0));
+}
+
+`;
+
+export default {
+  name: "slope",
+  fs,
+  getUniforms,
+  inject: {
+    "fs:DECKGL_MUTATE_COLOR": `
+    float scaleFactor = compute_mercator_scale_factor(latitude);
+    image.r = compute_slope(image.rg, scaleFactor);
+    `,
+  },
+};


### PR DESCRIPTION
To do:

- [ ] Compute pixel resolution from zoom
- [ ] Remove visual exaggeration applied in Mapbox GL
- [ ] Add vertex shader to handle 258px images
- [ ] Latitude correction
- [ ] Use `decode_terrain` shader as dependency of `deriv`, so that you only define `getElevation`/`decodeElevation` once?
- [ ] Aspect calculation