### PR TITLE
Add vector length module

### DIFF
--- a/src/webgl/index.js
+++ b/src/webgl/index.js
@@ -16,3 +16,6 @@ export {default as enhancedVegetationIndex} from './spectral-indices/evi';
 export {default as modifiedSoilAdjustedVegetationIndex} from './spectral-indices/msavi';
 export {default as normalizedDifference} from './spectral-indices/normalized-difference';
 export {default as soilAdjustedVegetationIndex} from './spectral-indices/savi';
+
+// Vector operations
+export {default as vectorLength} from './vector/vector-length';

--- a/src/webgl/vector/vector-length.fs.glsl
+++ b/src/webgl/vector/vector-length.fs.glsl
@@ -1,0 +1,4 @@
+// Calculate vector length
+float vector_length_calc(vec4 image) {
+  return length(vec2(image.r, image.g));
+}

--- a/src/webgl/vector/vector-length.js
+++ b/src/webgl/vector/vector-length.js
@@ -1,0 +1,11 @@
+import fs from './vector-length.fs.glsl';
+
+export default {
+  name: 'vector_length',
+  fs,
+  inject: {
+    'fs:DECKGL_MUTATE_COLOR': `
+    image = vec4(vector_length_calc(image), 0., 0., 0.);
+    `,
+  },
+};


### PR DESCRIPTION
Use case: for vector u, v encoded in two image bands, render a color overlay using vector length