### PR TITLE
Add colormap scaler and offset uniforms

### DIFF
--- a/src/webgl/color/colormap.fs.glsl
+++ b/src/webgl/color/colormap.fs.glsl
@@ -1,10 +1,12 @@
 uniform sampler2D u_colormap_texture;
+uniform float colormapScaler;
+uniform float colormapOffset;
 
 // Apply colormap texture given value
 // Since the texture only varies in the x direction, setting v to 0.5 as a
 // constant is fine
-// Assumes the input range of value is -1 to 1
-vec4 colormap(sampler2D cmap, vec4 image) {
-  vec2 uv = vec2(0.5 * image.r + 0.5, 0.5);
+// Default input range of value is -1 to 1
+vec4 colormap(sampler2D cmap, vec4 image, float scaler, float offset) {
+  vec2 uv = vec2(scaler * image.r + offset, 0.5);
   return texture2D(cmap, uv);
 }

--- a/src/webgl/color/colormap.js
+++ b/src/webgl/color/colormap.js
@@ -1,7 +1,7 @@
 import fs from './colormap.fs.glsl';
 
 function getUniforms(opts = {}) {
-  const {imageColormap} = opts;
+  const {imageColormap, colormapScaler, colormapOffset} = opts;
 
   if (!imageColormap) {
     return;
@@ -9,6 +9,8 @@ function getUniforms(opts = {}) {
 
   return {
     u_colormap_texture: imageColormap,
+    colormapScaler: Number.isFinite(colormapScaler) ? colormapScaler : 0.5,
+    colormapOffset: Number.isFinite(colormapOffset) ? colormapOffset : 0.5,
   };
 }
 
@@ -18,7 +20,7 @@ export default {
   getUniforms,
   inject: {
     'fs:DECKGL_MUTATE_COLOR': `
-    image = colormap(u_colormap_texture, image);
+    image = colormap(u_colormap_texture, image, colormapScaler, colormapOffset);
     `,
   },
 };


### PR DESCRIPTION
Usecase: to be able to use colormap on values [0..1] (scaler = 1, offset = 0; these values might even be default)

linearRescale could be used for this usecase before colormap. However, a module can't be used multiple times in the same shader (#39). In my case (#58), I need either a duplicate linearRescale2 module, or configurable scaler/offset uniforms in colormap.