### PR TITLE
Add support for BitmapLayer._imageCoordinateSystem

### DIFF
--- a/src/deckgl/raster-layer/raster-layer-webgl1.fs.glsl
+++ b/src/deckgl/raster-layer/raster-layer-webgl1.fs.glsl
@@ -5,11 +5,40 @@ precision highp float;
 #endif
 
 varying vec2 vTexCoord;
+varying vec2 vTexPos;
 
 uniform float desaturate;
 uniform vec4 transparentColor;
 uniform vec3 tintColor;
 uniform float opacity;
+
+uniform mediump float coordinateConversion;
+uniform vec4 bounds;
+
+/* projection utils */
+const float TILE_SIZE = 512.0;
+const float PI = 3.1415926536;
+const float WORLD_SCALE = TILE_SIZE / PI / 2.0;
+
+// from degrees to Web Mercator
+vec2 lnglat_to_mercator(vec2 lnglat) {
+  float x = lnglat.x;
+  float y = clamp(lnglat.y, -89.9, 89.9);
+  return vec2(
+    radians(x) + PI,
+    PI + log(tan(PI * 0.25 + radians(y) * 0.5))
+  ) * WORLD_SCALE;
+}
+
+// from Web Mercator to degrees
+vec2 mercator_to_lnglat(vec2 xy) {
+  xy /= WORLD_SCALE;
+  return degrees(vec2(
+    xy.x - PI,
+    atan(exp(xy.y - PI)) * 2.0 - PI * 0.5
+  ));
+}
+/* End projection utils */
 
 // apply desaturation
 vec3 color_desaturate(vec3 color) {
@@ -27,14 +56,29 @@ vec4 apply_opacity(vec3 color, float alpha) {
   return mix(transparentColor, vec4(color, 1.0), alpha);
 }
 
-void main(void) {
-  vec4 image;
-  DECKGL_CREATE_COLOR(image, vTexCoord);
+vec2 getUV(vec2 pos) {
+  return vec2(
+    (pos.x - bounds[0]) / (bounds[2] - bounds[0]),
+    (pos.y - bounds[3]) / (bounds[1] - bounds[3])
+  );
+}
 
-  DECKGL_MUTATE_COLOR(image, vTexCoord);
+void main(void) {
+  vec2 uv = vTexCoord;
+  if (coordinateConversion < -0.5) {
+    vec2 lnglat = mercator_to_lnglat(vTexPos);
+    uv = getUV(lnglat);
+  } else if (coordinateConversion > 0.5) {
+    vec2 commonPos = lnglat_to_mercator(vTexPos);
+    uv = getUV(commonPos);
+  }
+  vec4 image;
+  DECKGL_CREATE_COLOR(image, uv);
+
+  DECKGL_MUTATE_COLOR(image, uv);
 
   gl_FragColor = apply_opacity(color_tint(color_desaturate(image.rgb)), opacity);
 
-  geometry.uv = vTexCoord;
+  geometry.uv = uv;
   DECKGL_FILTER_COLOR(gl_FragColor, geometry);
 }

--- a/src/deckgl/raster-layer/raster-layer-webgl1.vs.glsl
+++ b/src/deckgl/raster-layer/raster-layer-webgl1.vs.glsl
@@ -5,6 +5,9 @@ attribute vec3 positions;
 attribute vec3 positions64Low;
 
 varying vec2 vTexCoord;
+varying vec2 vTexPos;
+
+uniform mediump float coordinateConversion;
 
 const vec3 pickingColor = vec3(1.0, 0.0, 0.0);
 
@@ -17,6 +20,12 @@ void main(void) {
   DECKGL_FILTER_GL_POSITION(gl_Position, geometry);
 
   vTexCoord = texCoords;
+
+  if (coordinateConversion < -0.5) {
+    vTexPos = geometry.position.xy;
+  } else if (coordinateConversion > 0.5) {
+    vTexPos = geometry.worldPosition.xy;
+  }
 
   vec4 color = vec4(0.0);
   DECKGL_FILTER_COLOR(color, geometry);

--- a/src/deckgl/raster-layer/raster-layer-webgl2.fs.glsl
+++ b/src/deckgl/raster-layer/raster-layer-webgl2.fs.glsl
@@ -7,6 +7,7 @@ precision mediump int;
 precision mediump usampler2D;
 
 in vec2 vTexCoord;
+in vec2 vTexPos;
 
 out vec4 color;
 
@@ -14,6 +15,34 @@ uniform float desaturate;
 uniform vec4 transparentColor;
 uniform vec3 tintColor;
 uniform float opacity;
+
+uniform mediump float coordinateConversion;
+uniform vec4 bounds;
+
+/* projection utils */
+const float TILE_SIZE = 512.0;
+const float PI = 3.1415926536;
+const float WORLD_SCALE = TILE_SIZE / PI / 2.0;
+
+// from degrees to Web Mercator
+vec2 lnglat_to_mercator(vec2 lnglat) {
+  float x = lnglat.x;
+  float y = clamp(lnglat.y, -89.9, 89.9);
+  return vec2(
+    radians(x) + PI,
+    PI + log(tan(PI * 0.25 + radians(y) * 0.5))
+  ) * WORLD_SCALE;
+}
+
+// from Web Mercator to degrees
+vec2 mercator_to_lnglat(vec2 xy) {
+  xy /= WORLD_SCALE;
+  return degrees(vec2(
+    xy.x - PI,
+    atan(exp(xy.y - PI)) * 2.0 - PI * 0.5
+  ));
+}
+/* End projection utils */
 
 // apply desaturation
 vec3 color_desaturate(vec3 color) {
@@ -31,14 +60,29 @@ vec4 apply_opacity(vec3 color, float alpha) {
   return mix(transparentColor, vec4(color, 1.0), alpha);
 }
 
-void main(void) {
-  vec4 image;
-  DECKGL_CREATE_COLOR(image, vTexCoord);
+vec2 getUV(vec2 pos) {
+  return vec2(
+    (pos.x - bounds[0]) / (bounds[2] - bounds[0]),
+    (pos.y - bounds[3]) / (bounds[1] - bounds[3])
+  );
+}
 
-  DECKGL_MUTATE_COLOR(image, vTexCoord);
+void main(void) {
+  vec2 uv = vTexCoord;
+  if (coordinateConversion < -0.5) {
+    vec2 lnglat = mercator_to_lnglat(vTexPos);
+    uv = getUV(lnglat);
+  } else if (coordinateConversion > 0.5) {
+    vec2 commonPos = lnglat_to_mercator(vTexPos);
+    uv = getUV(commonPos);
+  }
+  vec4 image;
+  DECKGL_CREATE_COLOR(image, uv);
+
+  DECKGL_MUTATE_COLOR(image, uv);
 
   color = apply_opacity(color_tint(color_desaturate(image.rgb)), opacity);
 
-  geometry.uv = vTexCoord;
+  geometry.uv = uv;
   DECKGL_FILTER_COLOR(color, geometry);
 }

--- a/src/deckgl/raster-layer/raster-layer-webgl2.vs.glsl
+++ b/src/deckgl/raster-layer/raster-layer-webgl2.vs.glsl
@@ -6,6 +6,9 @@ in vec3 positions;
 in vec3 positions64Low;
 
 out vec2 vTexCoord;
+out vec2 vTexPos;
+
+uniform mediump float coordinateConversion;
 
 const vec3 pickingColor = vec3(1.0, 0.0, 0.0);
 
@@ -18,6 +21,12 @@ void main(void) {
   DECKGL_FILTER_GL_POSITION(gl_Position, geometry);
 
   vTexCoord = texCoords;
+
+  if (coordinateConversion < -0.5) {
+    vTexPos = geometry.position.xy;
+  } else if (coordinateConversion > 0.5) {
+    vTexPos = geometry.worldPosition.xy;
+  }
 
   vec4 color = vec4(0.0);
   DECKGL_FILTER_COLOR(color, geometry);

--- a/src/deckgl/raster-layer/raster-layer.js
+++ b/src/deckgl/raster-layer/raster-layer.js
@@ -43,7 +43,7 @@ export default class RasterLayer extends BitmapLayer {
   }
 
   draw({uniforms}) {
-    const {model, images} = this.state;
+    const {model, images, coordinateConversion, bounds} = this.state;
     const {desaturate, transparentColor, tintColor, moduleProps} = this.props;
 
     // Render the image
@@ -62,6 +62,8 @@ export default class RasterLayer extends BitmapLayer {
           desaturate,
           transparentColor: transparentColor.map((x) => x / 255),
           tintColor: tintColor.slice(0, 3).map((x) => x / 255),
+          coordinateConversion,
+          bounds
         })
       )
       .updateModuleSettings({
@@ -122,7 +124,9 @@ export default class RasterLayer extends BitmapLayer {
           attributeManager.invalidate(key);
         }
       }
-      this.setState({mesh});
+      this.setState({mesh, ...this._getCoordinateUniforms()});
+    } else if (props._imageCoordinateSystem !== oldProps._imageCoordinateSystem) {
+      this.setState(this._getCoordinateUniforms());
     }
   }
 


### PR DESCRIPTION
New code from https://github.com/visgl/deck.gl/pull/5154 is duplicated here. It would be great to automatically support such BitmapLayer features without duplication though.