### PR TITLE
Add support for overriding individual texture parameters

### DIFF
--- a/src/deckgl/images.js
+++ b/src/deckgl/images.js
@@ -79,8 +79,11 @@ function loadTexture(gl, imageData) {
   }
 
   let textureParams = {
-    parameters: DEFAULT_TEXTURE_PARAMETERS,
     ...imageData,
+    parameters: {
+      ...DEFAULT_TEXTURE_PARAMETERS,
+      ...imageData.parameters,
+    },
   };
 
   if (!isWebGL2(gl)) {


### PR DESCRIPTION
Usecase: override individual texture parameters (e.g. for linear filtering)

Custom texture parameters are currently possible by passing all texture parameters. This PR makes the behavior similar to BitmapLayer, so that it's possible to override individual parameters only, without passing default parameters.