### PR TITLE
Add mask image module using alpha channel

### DIFF
--- a/src/deckgl/raster-layer/raster-layer-webgl1.fs.glsl
+++ b/src/deckgl/raster-layer/raster-layer-webgl1.fs.glsl
@@ -33,7 +33,7 @@ void main(void) {
 
   DECKGL_MUTATE_COLOR(image, vTexCoord);
 
-  gl_FragColor = apply_opacity(color_tint(color_desaturate(image.rgb)), opacity);
+  gl_FragColor = apply_opacity(color_tint(color_desaturate(image.rgb)), image.a * opacity);
 
   geometry.uv = vTexCoord;
   DECKGL_FILTER_COLOR(gl_FragColor, geometry);

--- a/src/deckgl/raster-layer/raster-layer-webgl2.fs.glsl
+++ b/src/deckgl/raster-layer/raster-layer-webgl2.fs.glsl
@@ -37,7 +37,7 @@ void main(void) {
 
   DECKGL_MUTATE_COLOR(image, vTexCoord);
 
-  color = apply_opacity(color_tint(color_desaturate(image.rgb)), opacity);
+  color = apply_opacity(color_tint(color_desaturate(image.rgb)), image.a * opacity);
 
   geometry.uv = vTexCoord;
   DECKGL_FILTER_COLOR(color, geometry);

--- a/src/webgl/index.js
+++ b/src/webgl/index.js
@@ -1,6 +1,7 @@
 // Create texture
 export {default as combineBands} from './texture/combine-bands';
 export {default as rgbaImage} from './texture/rgba-image';
+export {default as maskImage} from './texture/mask-image';
 
 // Color operations
 export {default as colormap} from './color/colormap';

--- a/src/webgl/texture/mask-image.js
+++ b/src/webgl/texture/mask-image.js
@@ -1,0 +1,27 @@
+function getUniforms(opts = {}) {
+  const {imageMask} = opts;
+
+  if (!imageMask) {
+    return;
+  }
+
+  return {
+    bitmapTexture_mask: imageMask,
+  };
+}
+
+const fs = `\
+uniform sampler2D bitmapTexture_mask;
+`;
+
+export default {
+  name: 'mask-image',
+  fs,
+  getUniforms,
+  inject: {
+    'fs:DECKGL_MUTATE_COLOR': `
+    float alpha = float(texture2D(bitmapTexture_mask, coord).a);
+    image = vec4(image.rgb, alpha);
+    `,
+  },
+};


### PR DESCRIPTION
Use a separate texture for masking the final image.

PNG with alpha channel can be used for both calculation and masking:
- set imageRgba for rgbaTexture to the image with RGB texture format
- set imageMask for maskImage to the same image with ALPHA texture format

If maskImage is not used, the possibility to use all four channels in source image for calculations is retained. (necessary until #42 is implemented) Existing modules and examples are unaffected.

Fixes #7